### PR TITLE
Fixing some copy & paste problems in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,15 @@ a usb connection.
 
 #### Clone the repository and compile
 
-    git clone git://github.com/OpenRoberta/robertalab-usbprogram.git
-    cd robertalab-usbprogram/OpenRobertaUSB
+    git clone git://github.com/OpenRoberta/robertalab-usbprogram-nxt.git
+    cd robertalab-usbprogram-nxt/OpenRobertaUSBNXT
     mvn clean install
 
 
 ### Run USB program
 For running the USB program use 32bit Java.
 
-    java -jar -Dfile.encoding=utf-8 ./OpenRobertaUSB/target/OpenRobertaUSB-*-SNAPSHOT.jar
+    java -jar -Dfile.encoding=utf-8 ./OpenRobertaUSBNXT/target/OpenRobertaUSB-*-SNAPSHOT.jar
 
 #### Linux and NXT
 For using the NXT install the following libraries

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ a usb connection.
 ### Run USB program
 For running the USB program use 32bit Java.
 
-    java -jar -Dfile.encoding=utf-8 ./OpenRobertaUSBNXT/target/OpenRobertaUSB-*-SNAPSHOT.jar
+    java -jar -Dfile.encoding=utf-8 ./OpenRobertaUSBNXT/target/OpenRobertaUSBNXT-*-SNAPSHOT.jar
 
 #### Linux and NXT
 For using the NXT install the following libraries


### PR DESCRIPTION
It looks like `README.md` was copied from the generic USB repository and e.g. the clone URL does not point to the NXT specific repository.